### PR TITLE
Tolerate missing nbf/exp when verifying token

### DIFF
--- a/lib/authex/verifier.ex
+++ b/lib/authex/verifier.ex
@@ -28,12 +28,20 @@ defmodule Authex.Verifier do
     end
   end
 
+  defp check_nbf(_, nbf) when is_nil(nbf) do
+    :ok
+  end
+
   defp check_nbf(time, nbf) when is_integer(nbf) and time > nbf do
     :ok
   end
 
   defp check_nbf(_, _) do
     {:error, :not_ready}
+  end
+
+  defp check_exp(_, exp) when is_nil(exp) do
+    :ok
   end
 
   defp check_exp(time, exp) when is_integer(exp) and time < exp do

--- a/test/authex/authex_test.exs
+++ b/test/authex/authex_test.exs
@@ -113,6 +113,13 @@ defmodule AuthexTest do
       assert {:error, :not_ready} = Auth.verify(compact_token)
     end
 
+    test "returns an ok tuple if the token has no nbf or exp claims" do
+      save_config(secret: "foo")
+      token = %{Auth.token() | nbf: nil, exp: nil}
+      compact_token = Auth.sign(token)
+      assert {:ok, %Token{}} = Auth.verify(compact_token)
+    end
+
     test "returns a duplicate of the original token" do
       save_config(secret: "foo")
       token = Auth.token()


### PR DESCRIPTION
@nsweeting thanks for this package! I like that it's tightly focussed and simple to use.

I am using it to verify JWTs from auth0 - hence, the tokens have not been generated by authex. auth0 JWTs do not provide an `nbf` claim, so they were failing to verify with a `:not_ready` error.

It's reasonable for authex to be less opinionated about `nbf` and `exp`, for uses like mine?